### PR TITLE
fix(build): Add dxc on FreeBSD

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -286,7 +286,7 @@ jobs:
             sudo pkg install -y cmake evdev-proto git gmake libX11 libXcursor libXext \
               libXfixes libXi libXrandr libXrender libXScrnSaver libXtst libglvnd \
               libinotify llvm21 ninja patchelf pkgconf python3 vulkan-loader zip \
-              glslang shaderc vulkan-headers
+              glslang shaderc vulkan-headers dxc
 
             if [ ${{ matrix.build-set.library-only}} = 'no' ]; then
               ${{ github.workspace }}/vcpkg/bootstrap-vcpkg.sh

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -136,7 +136,7 @@ Install required packages:
 ```sh
 pkg install cmake evdev-proto git gmake libX11 libXcursor libXext libXfixes libXi \
     libXrandr libXrender libXScrnSaver libXtst libglvnd libinotify llvm19 ninja patchelf \
-    pkgconf python3 vulkan-loader zip glslang shaderc vulkan-headers
+    pkgconf python3 vulkan-loader zip glslang shaderc vulkan-headers dxc
 ```
 
 Notes:


### PR DESCRIPTION
Microsoft's DirectX Shader Compiler is a required build dependency and needs to be installed in the build environment.

This is currently a WIP/draft PR. DXC isn't available as a port/package on FreeBSD yet. I proposed a port in https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=298058, which I hope will be accepted.